### PR TITLE
Base socket with new callback system

### DIFF
--- a/example/async_tcp_example.cpp
+++ b/example/async_tcp_example.cpp
@@ -79,9 +79,12 @@ int main(int argc, char**argv)
 
             std::this_thread::sleep_for(std::chrono::milliseconds(2000));
             std::string_view buffer {"Hello world from the second accepted connection!"};
-            sock.send(net::span {buffer.begin(), buffer.end()});
+            sock.async_send(net::span {buffer.begin(), buffer.end()}, [](size_t) {
+                std::cout << "Message sent\n";
+            });
 
             std::cout << "Sent\n";
+            std::this_thread::sleep_for(std::chrono::milliseconds(2000));
         }
     }
 }

--- a/example/async_udp_example.cpp
+++ b/example/async_udp_example.cpp
@@ -14,8 +14,12 @@ int main(int argc, char** argv)
         net::udp_socket<net::ip_version::v4> sock {"0.0.0.0", 4433};
         std::array<char, 1024> buffer;
 
-        sock.async_read(net::span {buffer}, [&buffer](size_t bytes) {
+        sock.async_read(net::span {buffer}, [&sock, &buffer](size_t bytes) {
             std::cout << "Received " << bytes << " bytes. -- " << std::string_view {buffer.data(), bytes} << '\n';
+
+            sock.async_read(net::span {buffer}, [&buffer](size_t bytes) {
+                std::cout << "Inner received " << bytes << " bytes. -- " << std::string_view {buffer.data(), bytes} << '\n';
+            });
         });
 
         std::cout << "Waiting ...\n";

--- a/example/async_udp_example.cpp
+++ b/example/async_udp_example.cpp
@@ -22,6 +22,14 @@ int main(int argc, char** argv)
             });
         });
 
+        sock.async_read(net::span {buffer}, [&sock, &buffer](size_t bytes) {
+            std::cout << "Received " << bytes << " bytes. -- " << std::string_view {buffer.data(), bytes} << '\n';
+
+            sock.async_read(net::span {buffer}, [&buffer](size_t bytes) {
+                std::cout << "Inner received " << bytes << " bytes. -- " << std::string_view {buffer.data(), bytes} << '\n';
+            });
+        });
+
         std::cout << "Waiting ...\n";
         std::this_thread::sleep_for(std::chrono::milliseconds(10000));
     }

--- a/include/socketwrapper/detail/async.hpp
+++ b/include/socketwrapper/detail/async.hpp
@@ -39,6 +39,10 @@ class async_context
     //  [Gets never called]
     struct no_op_callback : public abstract_socket_callback
     {
+        no_op_callback()
+            : abstract_socket_callback {nullptr}
+        {}
+
         void operator()() const override
         {}
     };

--- a/include/socketwrapper/detail/async.hpp
+++ b/include/socketwrapper/detail/async.hpp
@@ -1,8 +1,10 @@
 #ifndef SOCKETWRAPPER_NET_INTERNAL_ASYNC_HPP
 #define SOCKETWRAPPER_NET_INTERNAL_ASYNC_HPP
 
+#include "callbacks.hpp"
 #include "threadpool.hpp"
 
+#include <memory>
 #include <array>
 #include <map>
 #include <future>
@@ -30,7 +32,15 @@ class async_context
     struct context_item
     {
         epoll_event event;
-        std::function<void()> callback;
+        async_callback callback;
+    };
+
+    /// No op callback used to add the pipe file descriptor to manage the async_context
+    //  [Gets never called]
+    struct no_op_callback : public abstract_socket_callback
+    {
+        void operator()() const override
+        {}
     };
 
 public:
@@ -68,7 +78,10 @@ public:
     template<typename CALLBACK_TYPE>
     bool add(const int sock_fd, const event_type type, CALLBACK_TYPE&& callback)
     {
-        if(const auto [inserted, success] = m_store.insert_or_assign(sock_fd, context_item {}); success)
+        if(const auto [inserted, success] = m_store.insert_or_assign(
+                sock_fd,
+                context_item {epoll_event {}, std::forward<CALLBACK_TYPE>(callback)}
+        ); success)
         {
             auto& item = inserted->second;
             item.event.events = type | EPOLLET;
@@ -79,7 +92,7 @@ public:
                 return false;
             }
 
-            item.callback = std::forward<CALLBACK_TYPE>(callback);
+            // item.callback = std::forward<CALLBACK_TYPE>(callback);
 
             // Restart loop with updated fd set
             const uint8_t control_byte = RELOAD_FD_SET;
@@ -108,6 +121,25 @@ public:
         return false;
     }
 
+    bool socket_registered(const int sock_fd) const
+    {
+        if(const auto& it = m_store.find(sock_fd); it != m_store.end())
+            return true;
+        else
+            return false;
+    }
+
+    bool callback_update_socket(const int sock_fd, const base_socket* new_ptr)
+    {
+        if(const auto& it = m_store.find(sock_fd); it != m_store.end())
+        {
+            // TODO Check if new_ptr has same type than the old one
+            it->second.callback.reset_socket_ptr(new_ptr);
+            return true;
+        }
+        return false;
+    }
+
 private:
 
     async_context()
@@ -120,7 +152,8 @@ private:
             throw std::runtime_error {"Failed to create pipe when instantiating class message_notifier."};
 
         // Add the pipe to the epoll monitoring set
-        auto [pipe_item_it, success] = m_store.emplace(m_pipe_fds[0], context_item {});
+        auto [pipe_item_it, success] = m_store.emplace(m_pipe_fds[0],
+            context_item {epoll_event{}, no_op_callback {}});
         pipe_item_it->second.event.events = EPOLLIN;
         pipe_item_it->second.event.data.fd = m_pipe_fds[0];
         ::epoll_ctl(m_epfd, EPOLL_CTL_ADD, m_pipe_fds[0], &(pipe_item_it->second.event));

--- a/include/socketwrapper/detail/base_socket.hpp
+++ b/include/socketwrapper/detail/base_socket.hpp
@@ -3,7 +3,6 @@
 
 #include "utility.hpp"
 #include "async.hpp"
-#include <iostream>
 
 #include "unistd.h"
 

--- a/include/socketwrapper/detail/base_socket.hpp
+++ b/include/socketwrapper/detail/base_socket.hpp
@@ -11,7 +11,6 @@ namespace net {
 namespace detail {
 
 /// Very simple socket base class
-template<ip_version IP_VER>
 class base_socket
 {
 public:
@@ -32,14 +31,16 @@ public:
             m_sockfd = rhs.m_sockfd;
             m_family = rhs.m_family;
 
+            async_context::instance().callback_update_socket(m_sockfd, this);
+
             rhs.m_sockfd = -1;
         }
         return *this;
     }
 
-    base_socket(socket_type type)
-        : m_sockfd {::socket(static_cast<uint8_t>(IP_VER), static_cast<uint8_t>(type), 0)},
-          m_family {IP_VER}
+    base_socket(socket_type type, ip_version ip_ver)
+        : m_sockfd {::socket(static_cast<uint8_t>(ip_ver), static_cast<uint8_t>(type), 0)},
+          m_family {ip_ver}
     {
         detail::init_socket_system();
 

--- a/include/socketwrapper/detail/base_socket.hpp
+++ b/include/socketwrapper/detail/base_socket.hpp
@@ -1,0 +1,108 @@
+#ifndef SOCKETWRAPPER_NET_INTERNAL_BASE_SOCKET_HPP
+#define SOCKETWRAPPER_NET_INTERNAL_BASE_SOCKET_HPP
+
+#include "utility.hpp"
+#include "async.hpp"
+#include <iostream>
+
+#include "unistd.h"
+
+namespace net {
+
+namespace detail {
+
+/// Very simple socket base class
+template<ip_version IP_VER>
+class base_socket
+{
+public:
+
+    base_socket(const base_socket&) = delete;
+    base_socket& operator=(const base_socket&) = delete;
+
+    base_socket(base_socket&& rhs) noexcept
+    {
+        *this = std::move(rhs);
+    }
+
+    base_socket& operator=(base_socket&& rhs) noexcept
+    {
+        // Provide custom move assginment operator to prevent the moved socket from closing the underlying file descriptor
+        if(this != &rhs)
+        {
+            m_sockfd = rhs.m_sockfd;
+            m_family = rhs.m_family;
+
+            rhs.m_sockfd = -1;
+        }
+        return *this;
+    }
+
+    base_socket(socket_type type)
+        : m_sockfd {::socket(static_cast<uint8_t>(IP_VER), static_cast<uint8_t>(type), 0)},
+          m_family {IP_VER}
+    {
+        detail::init_socket_system();
+
+        if(m_sockfd == -1)
+            throw std::runtime_error {"Failed to create socket."};
+
+        const int reuse = 1;
+        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+            throw std::runtime_error {"Failed to set address reusable."};
+
+#ifdef SO_REUSEPORT
+        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
+            throw std::runtime_error {"Failed to set port reusable."};
+#endif
+    }
+
+    ~base_socket()
+    {
+        if(m_sockfd > 0)
+        {
+            // TODO only do this when the socket is still in the async context
+            detail::async_context::instance().remove(m_sockfd);
+            ::close(m_sockfd);
+        }
+    }
+
+    int get() const
+    {
+        return m_sockfd;
+    }
+
+    ip_version family() const
+    {
+        return m_family;
+    }
+
+protected:
+
+    base_socket(int sockfd, ip_version ip_ver)
+        : m_sockfd {sockfd},
+          m_family {ip_ver}
+    {
+        if(m_sockfd == -1)
+            throw std::runtime_error {"Failed to create socket."};
+
+        const int reuse = 1;
+        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+            throw std::runtime_error {"Failed to set address reusable."};
+
+#ifdef SO_REUSEPORT
+        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
+            throw std::runtime_error {"Failed to set port reusable."};
+#endif
+    }
+
+    int m_sockfd;
+
+    ip_version m_family;
+};
+
+} // namespace detail
+
+} // namespace net
+
+#endif

--- a/include/socketwrapper/detail/callbacks.hpp
+++ b/include/socketwrapper/detail/callbacks.hpp
@@ -40,8 +40,7 @@ public:
 
     void operator()() const
     {
-        if(m_ptr)
-            (*m_ptr)();
+        (*m_ptr)();
     }
 
     void reset_socket_ptr(const base_socket* new_ptr)

--- a/include/socketwrapper/detail/callbacks.hpp
+++ b/include/socketwrapper/detail/callbacks.hpp
@@ -14,8 +14,11 @@ class base_socket;
 //      to "move" active asynchronous operations with a moved socket
 struct abstract_socket_callback
 {
-    virtual ~abstract_socket_callback()
+    abstract_socket_callback(const base_socket* ptr)
+        : socket_ptr {ptr}
     {}
+
+    virtual ~abstract_socket_callback() = default;
 
     virtual void operator()() const = 0;
 
@@ -27,9 +30,9 @@ class async_callback final
 {
 public:
 
-    template<typename USER_CALLBACK>
-    async_callback(USER_CALLBACK&& cb)
-        : m_ptr {std::make_unique<USER_CALLBACK>(std::forward<USER_CALLBACK>(cb))}
+    template<typename DERIVED_CALLBACK>
+    async_callback(DERIVED_CALLBACK&& cb)
+        : m_ptr {std::make_unique<DERIVED_CALLBACK>(std::forward<DERIVED_CALLBACK>(cb))}
     {}
 
     async_callback(const async_callback&) = delete;

--- a/include/socketwrapper/detail/callbacks.hpp
+++ b/include/socketwrapper/detail/callbacks.hpp
@@ -1,0 +1,62 @@
+#ifndef SOCKETWRAPPER_NET_DETAIL_CALLBACKS_HPP
+#define SOCKETWRAPPER_NET_DETAIL_CALLBACKS_HPP
+
+#include <memory>
+
+namespace net {
+
+namespace detail {
+
+/// Forward declarations
+class base_socket;
+
+/// Abstract callback type providing a pointer to the socket that issued the callback
+//      to "move" active asynchronous operations with a moved socket
+struct abstract_socket_callback
+{
+    virtual ~abstract_socket_callback()
+    {}
+
+    virtual void operator()() const = 0;
+
+    const base_socket* socket_ptr;
+};
+
+/// Type erased callback for all asynchronous operations
+class async_callback final
+{
+public:
+
+    template<typename USER_CALLBACK>
+    async_callback(USER_CALLBACK&& cb)
+        : m_ptr {std::make_unique<USER_CALLBACK>(std::forward<USER_CALLBACK>(cb))}
+    {}
+
+    async_callback(const async_callback&) = delete;
+    async_callback& operator=(const async_callback&) = delete;
+    async_callback(async_callback&&) = default;
+    async_callback& operator=(async_callback&&) = default;
+    ~async_callback() = default;
+
+    void operator()() const
+    {
+        if(m_ptr)
+            (*m_ptr)();
+    }
+
+    void reset_socket_ptr(const base_socket* new_ptr)
+    {
+        m_ptr->socket_ptr = new_ptr;
+    }
+
+private:
+
+    std::unique_ptr<abstract_socket_callback> m_ptr;
+};
+
+
+} // namespace detail
+
+} // namespace net
+
+#endif

--- a/include/socketwrapper/detail/threadpool.hpp
+++ b/include/socketwrapper/detail/threadpool.hpp
@@ -1,6 +1,8 @@
 #ifndef SOCKETWRAPPER_NET_INTERNAL_THREADPOOL_HPP
 #define SOCKETWRAPPER_NET_INTERNAL_THREADPOOL_HPP
 
+#include "callbacks.hpp"
+
 #include <vector>
 #include <queue>
 #include <thread>
@@ -62,7 +64,7 @@ public:
         m_workers.clear();
     }
 
-    void add_job(std::function<void()> func)
+    void add_job(async_callback&& func)
     {
         {
             const std::lock_guard<std::mutex> lock {m_qmutex};
@@ -106,7 +108,7 @@ private:
 
     std::vector<std::thread> m_workers;
 
-    std::queue<std::function<void()>> m_queue;
+    std::queue<async_callback> m_queue;
 
     std::mutex m_qmutex;
 

--- a/include/socketwrapper/tcp.hpp
+++ b/include/socketwrapper/tcp.hpp
@@ -18,8 +18,6 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#include <iostream>
-
 namespace net {
 
 template<ip_version IP_VER>

--- a/include/socketwrapper/tcp.hpp
+++ b/include/socketwrapper/tcp.hpp
@@ -2,6 +2,7 @@
 #define SOCKETWRAPPER_NET_TCP_HPP
 
 #include "span.hpp"
+#include "detail/base_socket.hpp"
 #include "detail/utility.hpp"
 #include "detail/async.hpp"
 #include "detail/message_notifier.hpp"
@@ -20,7 +21,7 @@
 namespace net {
 
 template<ip_version IP_VER>
-class tcp_connection
+class tcp_connection : public detail::base_socket<IP_VER>
 {
 protected:
 
@@ -36,8 +37,12 @@ public:
     tcp_connection& operator=(const tcp_connection&) = delete;
 
     tcp_connection(tcp_connection&& rhs) noexcept
+        : detail::base_socket<IP_VER> {std::move(rhs)}
     {
-        *this = std::move(rhs);
+        m_peer = std::move(rhs.m_peer);
+        m_connection = rhs.m_connection;
+
+        rhs.m_connection = connection_status::closed;
     }
 
     tcp_connection& operator=(tcp_connection&& rhs) noexcept
@@ -45,49 +50,34 @@ public:
         // Provide custom move assginment operator to prevent the moved socket from closing the underlying file descriptor
         if(this != &rhs)
         {
-            m_sockfd = rhs.m_sockfd;
-            m_family = rhs.m_family;
+            detail::base_socket<IP_VER>::operator=(std::move(rhs));
+
             m_peer = std::move(rhs.m_peer);
             m_connection = rhs.m_connection;
 
-            rhs.m_sockfd = -1;
             rhs.m_connection = connection_status::closed;
         }
         return *this;
     }
 
     tcp_connection(const std::string_view conn_addr, const uint16_t port_to)
-        : m_sockfd {::socket(static_cast<uint8_t>(IP_VER), static_cast<uint8_t>(socket_type::stream), 0)}, m_family {IP_VER},
+        : detail::base_socket<IP_VER> {socket_type::stream},
           m_connection {connection_status::closed}
     {
-        detail::init_socket_system();
-
-        if(m_sockfd == -1)
-            throw std::runtime_error {"Failed to created socket."};
-
-        const int reuse = 1;
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
-            throw std::runtime_error {"Failed to set address reusable."};
-
-#ifdef SO_REUSEPORT
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
-            throw std::runtime_error {"Failed to set port reusable."};
-#endif
-
         if(detail::resolve_hostname<IP_VER>(conn_addr, port_to, socket_type::stream, m_peer) != 0)
             throw std::runtime_error {"Failed to resolve hostname."};
 
         if constexpr(IP_VER == ip_version::v4)
         {
             auto& ref = std::get<sockaddr_in>(m_peer);
-            if(auto res = ::connect(m_sockfd, reinterpret_cast<sockaddr*>(&ref), sizeof(sockaddr_in)); res != 0)
+            if(auto res = ::connect(this->m_sockfd, reinterpret_cast<sockaddr*>(&ref), sizeof(sockaddr_in)); res != 0)
                 throw std::runtime_error {"Failed to connect."};
             m_connection = connection_status::connected;
         }
         else if constexpr(IP_VER == ip_version::v6)
         {
             auto& ref = std::get<sockaddr_in6>(m_peer);
-            if(auto res = ::connect(m_sockfd, reinterpret_cast<sockaddr*>(&ref), sizeof(sockaddr_in)); res != 0)
+            if(auto res = ::connect(this->m_sockfd, reinterpret_cast<sockaddr*>(&ref), sizeof(sockaddr_in)); res != 0)
                 throw std::runtime_error {"Failed to connect."};
             m_connection = connection_status::connected;
         }
@@ -95,21 +85,6 @@ public:
         {
             static_assert(IP_VER == ip_version::v4 || IP_VER == ip_version::v6);
         }
-    }
-
-    ~tcp_connection()
-    {
-        if(m_connection != connection_status::closed && m_sockfd > 0)
-        {
-            // TODO only do this when the socket is still in the async context
-            detail::async_context::instance().remove(m_sockfd);
-            ::close(m_sockfd);
-        }
-    }
-
-    int get() const
-    {
-        return m_sockfd;
     }
 
     template<typename T>
@@ -143,7 +118,7 @@ public:
     void async_send(span<T>&& buffer, CALLBACK_TYPE&& callback) const
     {
         detail::async_context::instance().add(
-            m_sockfd,
+            this->m_sockfd,
             detail::async_context::WRITE,
             [this, buffer = std::move(buffer), func = std::forward<CALLBACK_TYPE>(callback)]() {
                 size_t bytes_written = send(std::move(buffer));
@@ -181,11 +156,11 @@ public:
         std::condition_variable cv;
         std::mutex mut;
         std::unique_lock<std::mutex> lock {mut};
-        notifier.add(m_sockfd, &cv);
+        notifier.add(this->m_sockfd, &cv);
 
         // Wait for given delay
         const bool ready = cv.wait_for(lock, delay) == std::cv_status::no_timeout;
-        notifier.remove(m_sockfd);
+        notifier.remove(this->m_sockfd);
 
         if(ready)
             return read(span {buffer});
@@ -197,14 +172,14 @@ public:
     void async_read(span<T>&& buffer, CALLBACK_TYPE&& callback) const
     {
         detail::async_context::instance().add(
-            m_sockfd,
+            this->m_sockfd,
             detail::async_context::READ,
             [this, buffer = std::move(buffer), func = std::forward<CALLBACK_TYPE>(callback)]()
             {
                 // Ok to create new span because its a cheap type containing only a view to the real buffer
                 size_t bytes_read = read(span<T> {buffer});
                 if(bytes_read == 0)
-                    detail::async_context::instance().remove(m_sockfd);
+                    detail::async_context::instance().remove(this->m_sockfd);
                 func(bytes_read);
             }
         );
@@ -215,30 +190,30 @@ protected:
     tcp_connection() = default;
 
     tcp_connection(const int socket_fd, const sockaddr_in& peer_addr)
-        : m_sockfd {socket_fd}, m_family {ip_version::v4}, m_peer {peer_addr}, m_connection {connection_status::connected}
+        : detail::base_socket<IP_VER> {socket_fd, ip_version::v4},
+          m_peer {peer_addr},
+          m_connection {connection_status::connected}
     {
         static_assert(IP_VER == ip_version::v4);
     }
 
     tcp_connection(const int socket_fd, const sockaddr_in6& peer_addr)
-        : m_sockfd {socket_fd}, m_family {ip_version::v6}, m_peer {peer_addr}, m_connection {connection_status::connected}
+        : detail::base_socket<IP_VER> {socket_fd, ip_version::v6},
+          m_peer {peer_addr},
+          m_connection {connection_status::connected}
     {
         static_assert(IP_VER == ip_version::v6);
     }
 
     virtual int read_from_socket(char* const buffer_to, size_t bytes_to_read) const
     {
-        return ::recv(m_sockfd, buffer_to, bytes_to_read, 0);
+        return ::recv(this->m_sockfd, buffer_to, bytes_to_read, 0);
     }
 
     virtual int write_to_socket(const char* buffer_from, size_t bytes_to_write) const
     {
-        return ::send(m_sockfd, buffer_from, bytes_to_write, 0);
+        return ::send(this->m_sockfd, buffer_from, bytes_to_write, 0);
     }
-
-    int m_sockfd;
-
-    ip_version m_family;
 
     std::variant<sockaddr_in, sockaddr_in6> m_peer = {};
 
@@ -255,7 +230,7 @@ using tcp_connection_v6 = tcp_connection<ip_version::v6>;
 
 
 template<ip_version IP_VER>
-class tcp_acceptor
+class tcp_acceptor : public detail::base_socket<IP_VER>
 {
 public:
 
@@ -264,8 +239,9 @@ public:
     tcp_acceptor& operator=(const tcp_acceptor&) = delete;
 
     tcp_acceptor(tcp_acceptor&& rhs) noexcept
+        : detail::base_socket<IP_VER> {std::move(rhs)}
     {
-        *this = std::move(rhs);
+        m_sockaddr = std::move(rhs.m_sockaddr);
     }
 
     tcp_acceptor& operator=(tcp_acceptor&& rhs) noexcept
@@ -273,44 +249,29 @@ public:
         // Provide a custom move assginment operator to prevent the moved object from closing the underlying file descriptor
         if(this != &rhs)
         {
-            m_sockfd = rhs.m_sockfd;
-            m_family = rhs.m_family;
-            m_sockaddr = std::move(rhs.m_sockaddr);
+            detail::base_socket<IP_VER>::operator=(std::move(rhs));
 
-            rhs.m_sockfd = -1;
+            m_sockaddr = std::move(rhs.m_sockaddr);
         }
         return *this;
     }
 
     tcp_acceptor(const std::string_view bind_addr, const uint16_t port, const size_t backlog = 5)
-        : m_sockfd {::socket(static_cast<uint8_t>(IP_VER), static_cast<uint8_t>(socket_type::stream), 0)},
-          m_family {IP_VER}
+        : detail::base_socket<IP_VER> {socket_type::stream}
     {
-        if(m_sockfd == -1)
-            throw std::runtime_error {"Failed to create socket."};
-
-        const int reuse = 1;
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(int)) < 0)
-            throw std::runtime_error {"Failed to set address resusable."};
-
-#ifdef SO_REUSEPORT
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(int)) < 0)
-            throw std::runtime_error {"Failed to set port reusable."};
-#endif
-
         if(detail::resolve_hostname<IP_VER>(bind_addr, port, socket_type::stream, m_sockaddr) != 0)
             throw std::runtime_error {"Failed to resolve hostname."};
 
         if constexpr(IP_VER == ip_version::v4)
         {
             auto& sockaddr_ref = std::get<sockaddr_in>(m_sockaddr);
-            if(auto res = ::bind(m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in)); res != 0)
+            if(auto res = ::bind(this->m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in)); res != 0)
                 throw std::runtime_error {"Failed to bind."};
         }
         else if constexpr(IP_VER == ip_version::v6)
         {
             auto& sockaddr_ref = std::get<sockaddr_in6>(m_sockaddr);
-            if(auto res = ::bind(m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in6)); res != 0)
+            if(auto res = ::bind(this->m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in6)); res != 0)
                 throw std::runtime_error {"Failed to bind."};
         }
         else
@@ -318,19 +279,8 @@ public:
             static_assert(IP_VER == ip_version::v4 || IP_VER == ip_version::v6);
         }
 
-        if(const auto res = ::listen(m_sockfd, backlog); res != 0)
+        if(const auto res = ::listen(this->m_sockfd, backlog); res != 0)
             throw std::runtime_error {"Failed to initiate listen."};
-    }
-
-    ~tcp_acceptor()
-    {
-        if(m_sockfd > 0)
-            ::close(m_sockfd);
-    }
-
-    int get() const
-    {
-        return m_sockfd;
     }
 
     tcp_connection<IP_VER> accept() const
@@ -339,7 +289,7 @@ public:
         {
             sockaddr_in client {};
             socklen_t len = sizeof(sockaddr_in);
-            if(const int sock = ::accept(m_sockfd, reinterpret_cast<sockaddr*>(&client), &len); sock > 0)
+            if(const int sock = ::accept(this->m_sockfd, reinterpret_cast<sockaddr*>(&client), &len); sock > 0)
                 return tcp_connection<IP_VER> {sock, client};
             else
                 throw std::runtime_error {"Failed to accept."};
@@ -348,7 +298,7 @@ public:
         {
             sockaddr_in6 client {};
             socklen_t len = sizeof(sockaddr_in6);
-            if(const int sock = ::accept(m_sockfd, reinterpret_cast<sockaddr*>(&client), &len); sock > 0)
+            if(const int sock = ::accept(this->m_sockfd, reinterpret_cast<sockaddr*>(&client), &len); sock > 0)
                 return tcp_connection<IP_VER> {sock, client};
             else
                 throw std::runtime_error {"Failed to accept."};
@@ -365,11 +315,11 @@ public:
         std::condition_variable cv;
         std::mutex mut;
         std::unique_lock<std::mutex> lock {mut};
-        notifier.add(m_sockfd, &cv);
+        notifier.add(this->m_sockfd, &cv);
 
         // Wait for given delay
         const bool ready = cv.wait_for(lock, delay) == std::cv_status::no_timeout;
-        notifier.remove(m_sockfd);
+        notifier.remove(this->m_sockfd);
 
         if(ready)
             return std::optional<tcp_connection<IP_VER>> {accept()};
@@ -381,7 +331,7 @@ public:
     void async_accept(CALLBACK_TYPE&& callback) const
     {
         detail::async_context::instance().add(
-            m_sockfd,
+            this->m_sockfd,
             detail::async_context::READ,
             [this, func = std::forward<CALLBACK_TYPE>(callback)]()
             {
@@ -391,10 +341,6 @@ public:
     }
 
 protected:
-
-    int m_sockfd;
-
-    ip_version m_family;
 
     std::variant<sockaddr_in, sockaddr_in6> m_sockaddr {};
 

--- a/include/socketwrapper/tls.hpp
+++ b/include/socketwrapper/tls.hpp
@@ -62,8 +62,14 @@ public:
     tls_connection& operator=(const tls_connection&) = delete;
 
     tls_connection(tls_connection&& rhs) noexcept
+        : tcp_connection<IP_VER> {std::move(rhs)}
     {
-        *this = std::move(rhs);
+        m_context = std::move(rhs.m_context);
+        m_ssl = rhs.m_ssl;
+        m_certificate = std::move(rhs.m_certificate);
+        m_private_key = std::move(rhs.m_private_key);
+
+        rhs.m_ssl = nullptr;
     }
 
     tls_connection& operator=(tls_connection&& rhs) noexcept
@@ -71,7 +77,7 @@ public:
         // Provide custom move assginment operator to prevent moved object from deleting SSL context pointers
         if(this != &rhs)
         {
-            static_cast<tcp_connection<IP_VER>&>(*this) = std::move(rhs);
+            tcp_connection<IP_VER>::operator=(std::move(rhs));
 
             m_context = std::move(rhs.m_context);
             m_ssl = rhs.m_ssl;
@@ -182,8 +188,14 @@ public:
     tls_acceptor operator=(const tls_acceptor&) = delete;
 
     tls_acceptor(tls_acceptor& rhs) noexcept
+        : tcp_acceptor<IP_VER> {std::move(rhs)}
     {
-        *this = std::move(rhs);
+        m_certificate = std::move(rhs.m_certificate);
+        m_private_key = std::move(rhs.m_private_key);
+        m_context = std::move(rhs.m_context);
+        m_ssl = rhs.m_ssl;
+
+        rhs.m_ssl = nullptr;
     }
 
     tls_acceptor& operator=(tls_acceptor&& rhs) noexcept
@@ -191,7 +203,7 @@ public:
         // Provide custom move assginment operator to prevent moved object from deleting underlying SSL context
         if(this != &rhs)
         {
-            static_cast<tcp_acceptor<IP_VER>&>(*this) = std::move(rhs);
+            tcp_acceptor<IP_VER>::operator=(std::move(rhs));
 
             m_certificate = std::move(rhs.m_certificate);
             m_private_key = std::move(rhs.m_private_key);

--- a/include/socketwrapper/udp.hpp
+++ b/include/socketwrapper/udp.hpp
@@ -2,6 +2,7 @@
 #define SOCKETWRAPPER_NET_UDP_HPP
 
 #include "span.hpp"
+#include "detail/base_socket.hpp"
 #include "detail/utility.hpp"
 #include "detail/async.hpp"
 #include "detail/message_notifier.hpp"
@@ -21,7 +22,7 @@
 namespace net {
 
 template<ip_version IP_VER>
-class udp_socket
+class udp_socket : public detail::base_socket<IP_VER>
 {
 
     enum class socket_mode : uint8_t
@@ -36,14 +37,17 @@ public:
     udp_socket& operator=(const udp_socket&) = delete;
 
     udp_socket()
-        : m_sockfd {::socket(static_cast<uint8_t>(IP_VER), static_cast<uint8_t>(socket_type::datagram), 0)},
-          m_family {IP_VER},
+        : detail::base_socket<IP_VER> {socket_type::datagram},
           m_mode {socket_mode::non_bound}
     {}
 
     udp_socket(udp_socket&& rhs) noexcept
+        : detail::base_socket<IP_VER> {std::move(rhs)}
     {
-        *this = std::move(rhs);
+        m_mode = rhs.m_mode;
+        m_sockaddr = std::move(rhs.m_sockaddr);
+
+        rhs.m_sockfd = -1;
     }
 
     udp_socket& operator=(udp_socket&& rhs) noexcept
@@ -51,8 +55,8 @@ public:
         // Provide custom move assginment operator to prevent moved object from closing underlying file descriptor
         if(this != &rhs)
         {
-            m_sockfd = rhs.m_sockfd;
-            m_family = rhs.m_family;
+            detail::base_socket<IP_VER>::operator=(std::move(rhs));
+
             m_mode = rhs.m_mode;
             m_sockaddr = std::move(rhs.m_sockaddr);
 
@@ -62,56 +66,28 @@ public:
     }
 
     udp_socket(const std::string_view bind_addr, const uint16_t port)
-        : m_sockfd {::socket(static_cast<uint8_t>(IP_VER), static_cast<uint8_t>(socket_type::datagram), 0)},
-          m_family {IP_VER},
+        : detail::base_socket<IP_VER> {socket_type::datagram},
           m_mode {socket_mode::bound}
     {
-        if(m_sockfd == -1)
-            throw std::runtime_error {"Failed to create socket."};
-
-        const int reuse = 1;
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(int)) < 0)
-            throw std::runtime_error {"Failed to set address reuseable."};
-
-#ifdef SO_REUSEPORT
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(int)) < 0)
-            throw std::runtime_error {"Failed to set port reuseable."};
-#endif
-
         if(detail::resolve_hostname<IP_VER>(bind_addr, port, socket_type::datagram, m_sockaddr) != 0)
             throw std::runtime_error {"Failed to resolve hostname."};
 
         if constexpr(IP_VER == ip_version::v4)
         {
             auto& sockaddr_ref = std::get<sockaddr_in>(m_sockaddr);
-            if(auto res = ::bind(m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in)); res != 0)
+            if(auto res = ::bind(this->m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in)); res != 0)
                 throw std::runtime_error {"Failed to bind."};
         }
         else if constexpr(IP_VER == ip_version::v6)
         {
             auto& sockaddr_ref = std::get<sockaddr_in6>(m_sockaddr);
-            if(auto res = ::bind(m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in6)); res != 0)
+            if(auto res = ::bind(this->m_sockfd, reinterpret_cast<sockaddr*>(&sockaddr_ref), sizeof(sockaddr_in6)); res != 0)
                 throw std::runtime_error {"Failed to bind."};
         }
         else
         {
             static_assert(IP_VER == ip_version::v4 || IP_VER == ip_version::v6);
         }
-    }
-
-    ~udp_socket()
-    {
-        if(m_sockfd > 0)
-        {
-            // TODO only do this when the socket is still in the async context
-            detail::async_context::instance().remove(m_sockfd);
-            ::close(m_sockfd);
-        }
-    }
-
-    int get() const
-    {
-        return m_sockfd;
     }
 
     template<typename T>
@@ -135,7 +111,7 @@ public:
     void async_send(const std::string_view addr, const uint16_t port, span<T>&& buffer, CALLBACK_TYPE&& callback) const
     {
         detail::async_context::instance().add(
-            m_sockfd,
+            this->m_sockfd,
             detail::async_context::WRITE,
             [this, addr, port, buffer = std::move(buffer), func = std::forward<CALLBACK_TYPE>(callback)]()
             {
@@ -167,11 +143,11 @@ public:
         std::condition_variable cv;
         std::mutex mut;
         std::unique_lock<std::mutex> lock {mut};
-        notifier.add(m_sockfd, &cv);
+        notifier.add(this->m_sockfd, &cv);
 
         // Wait for given delay
         const bool ready = cv.wait_for(lock, delay) == std::cv_status::no_timeout;
-        notifier.remove(m_sockfd);
+        notifier.remove(this->m_sockfd);
 
         if(ready)
             return read(span {buffer});
@@ -183,7 +159,7 @@ public:
     void async_read(span<T>&& buffer, CALLBACK_TYPE&& callback) const
     {
         detail::async_context::instance().add(
-            m_sockfd,
+            this->m_sockfd,
             detail::async_context::READ,
             [this, buffer = std::move(buffer), func = std::forward<CALLBACK_TYPE>(callback)]()
             {
@@ -201,7 +177,7 @@ private:
         {
             socklen_t flen = sizeof(sockaddr_in);
             sockaddr_in from {};
-            const auto bytes = ::recvfrom(m_sockfd, buffer, size, 0, reinterpret_cast<sockaddr*>(&from), &flen);
+            const auto bytes = ::recvfrom(this->m_sockfd, buffer, size, 0, reinterpret_cast<sockaddr*>(&from), &flen);
 
             if(peer_data)
                 *peer_data = detail::resolve_addrinfo<IP_VER>(reinterpret_cast<sockaddr*>(&from));
@@ -212,7 +188,7 @@ private:
         {
             socklen_t flen = sizeof(sockaddr_in6);
             sockaddr_in6 from {};
-            const auto bytes = ::recvfrom(m_sockfd, buffer, size, 0, reinterpret_cast<sockaddr*>(&from), &flen);
+            const auto bytes = ::recvfrom(this->m_sockfd, buffer, size, 0, reinterpret_cast<sockaddr*>(&from), &flen);
 
             if(peer_data)
                 *peer_data = detail::resolve_addrinfo<IP_VER>(reinterpret_cast<sockaddr*>(&from));
@@ -234,22 +210,18 @@ private:
         if constexpr(IP_VER == ip_version::v4)
         {
             auto& dest_ref = std::get<sockaddr_in>(dest);
-            return ::sendto(m_sockfd, buffer, length, 0, reinterpret_cast<sockaddr*>(&dest_ref), sizeof(sockaddr_in));
+            return ::sendto(this->m_sockfd, buffer, length, 0, reinterpret_cast<sockaddr*>(&dest_ref), sizeof(sockaddr_in));
         }
         else if constexpr(IP_VER == ip_version::v6)
         {
             auto& dest_ref = std::get<sockaddr_in6>(dest);
-            return ::sendto(m_sockfd, buffer, length, 0, reinterpret_cast<sockaddr*>(&dest_ref), sizeof(sockaddr_in6));
+            return ::sendto(this->m_sockfd, buffer, length, 0, reinterpret_cast<sockaddr*>(&dest_ref), sizeof(sockaddr_in6));
         }
         else
         {
             static_assert(IP_VER == ip_version::v4 || IP_VER == ip_version::v6);
         }
     }
-
-    int m_sockfd;
-
-    ip_version m_family;
 
     socket_mode m_mode;
 


### PR DESCRIPTION
Implemented a non-template base clase for all sockets `base_socket` and used this to extend the callback system of the async context to keep track of the socket pointer in a callback to be able to call a callback on a moved socket.

Closes #3 and #5 