### PR TITLE
Add socket configuration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ This class is used in the methods ```base_socket::get_option```, ```base_socket:
 It is included implicitly with the class ```base_socket```.
 
 Methods:
+- Constructors:
     ```cpp
     option() = default;
     
     option(int value);
-    
+    ```
+- Accessors/Modifiers:
+    ```cpp
     size_t size() const;
     
     int name() const;

--- a/README.md
+++ b/README.md
@@ -23,7 +23,26 @@ Socket/connection classes all are not copyable but moveable and templated to dis
     {
         v4,
         v6
-    }
+    };
+```
+
+```cpp
+    enum class socket_type : uint8_t
+    {
+        unspecified = AF_UNSPEC,
+        stream = SOCK_STREAM,
+        datagram = SOCK_DGRAM
+    };
+```
+
+```cpp
+    enum class option_level : int
+    {
+        socket = SOL_SOCKET,
+        ipv4 = IPPROTO_IP
+        ipv6 = IPPROTO_IPV6
+        tcp = IPPROTO_TCP
+    };
 ```
 
 ### span<typename TYPE>
@@ -78,7 +97,67 @@ Methods:
     sockaddr& get_addr();
     ```
 
-### tcp_connection<ip_version IP_VER>
+### option<option_level LEVEL, int NAME, typename T>
+This class is used in the methods ```base_socket::get_option```, ```base_socket::get_option_value``` and ```base_socket::set_option``` to set and get socket options.
+It is included implicitly with the class ```base_socket```.
+
+Methods:
+    ```cpp
+    option() = default;
+    
+    option(int value);
+    
+    size_t size() const;
+    
+    int name() const;
+    
+    option_level level() const;
+    
+    int level_native() const;
+    
+    const int* value() const;
+    
+    int* value();
+    ```
+
+Valid template specializations for parameter T are:
+* int
+* bool
+* linger
+* sockaddr
+
+### base_socket
+This class is implicitly included with every socket class that inherits from the class ```base_socket```.
+
+Represents the basic functionalities of the native socket handle. The other high-level socket abstractions are all dervived from this class.
+Methods:
+- Set/get socket options:
+    ```cpp
+    // Set a socket option where the option is represented by a valid template specialization of net::option<net::option_level LEVEL, int NAME, typename T>
+    template <typename OPTION_TYPE,
+        typename = std::enable_if_t<detail::is_template_of<OPTION_TYPE, option>::value, bool>>
+    void set_option(OPTION_TYPE&& opt_val);
+    
+    // Get a current socket option where the option type needs to be a valid template specialization of net::option<net::option_level LEVEL, int NAME, typename T>
+    template <typename OPTION_TYPE,
+        typename = std::enable_if_t<detail::is_template_of<OPTION_TYPE, option>::value, bool>>
+    OPTION_TYPE get_option() const
+    
+    // Get the current value of a socket option where the option type needs to be a valid template specialization of net::option<net::option_level LEVEL, int NAME, typename T>
+    template <typename OPTION_TYPE,
+        typename = std::enable_if_t<detail::is_template_of<OPTION_TYPE, option>::value, bool>>
+    typename OPTION_TYPE::value_type get_option_value() const
+    ```
+- Other:
+    ```cpp
+    // Get the underlying socket handle
+    int get() const;
+    
+    // Get the ip version of the represented socket
+    ip_version family() const;
+    ```
+
+### tcp_connection<ip_version IP_VER> : public base_socket
 >#include "socketwrapper/tcp.hpp"
 
 Represents a TCP connection that can either be constructed with the IP address and port of the remote host or by a `tcp_acceptor<IP_VER>`s accept method.
@@ -130,7 +209,7 @@ Methods:
     using tcp_connection_v6 = tcp_connection<net::ip_version::v6>;
     ```
     
-### tcp_acceptor<ip_version IP_VER>
+### tcp_acceptor<ip_version IP_VER> public base_socket
 >#include "socketwrapper/tcp.hpp"
 
 Represents a listening TCP socket that accepts incoming connections. Returns a `tcp_connection<IP_VER>` for each accepted connection.
@@ -217,7 +296,7 @@ Methods:
     using tls_acceptor_v6 = tls_acceptor<net::ip_version::v6>;
     ```
 
-### udp_socket<ip_version IP_VER>
+### udp_socket<ip_version IP_VER> : public base_socket
 >#include "socketwrapper/udp.hpp"
 
 Represents an UDP socket that can either be in "server" or "client" position.

--- a/example/Makefile
+++ b/example/Makefile
@@ -38,6 +38,10 @@ async_udp: async_udp_example.cpp
 span: span_example.cpp
 	$(cc) -o span_example $^ $(CFLAGS) $(LDFLAGS)
 
+.PHONY: options
+options: options_example.cpp
+	$(cc) -o options_example $^ $(CFLAGS) $(LDFLAGS)
+
 .PHONY: clean
 clean:
 	rm tls_example
@@ -47,3 +51,4 @@ clean:
 	rm udp_example
 	rm async_udp_example
 	rm span_example
+	rm options_example

--- a/example/Makefile
+++ b/example/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -lpthread
 	$(cc) -c $< -o $@ $(CFLAGS)
 
 .PHONY: all
-all: tls async_tls tcp async_tcp udp async_udp span
+all: tls async_tls tcp async_tcp udp async_udp span options
 
 .PHONY: tls
 tls: tls_example.cpp

--- a/example/async_udp_example.cpp
+++ b/example/async_udp_example.cpp
@@ -29,7 +29,6 @@ int main(int argc, char** argv)
         sock.async_read(net::span {buffer},
             [&sock, &buffer](size_t bytes, net::endpoint_v4)
             {
-                std::cout << "UPDATED CALLBACK TIME!!\n";
                 std::cout << "Received " << bytes << " bytes. -- " << std::string_view {buffer.data(), bytes} << '\n';
 
                 sock.async_read(net::span {buffer},

--- a/example/options_example.cpp
+++ b/example/options_example.cpp
@@ -1,0 +1,36 @@
+#include "../include/socketwrapper/tcp.hpp"
+
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <string_view>
+#include <thread>
+
+int main()
+{
+    std::cout << "--- Options example ---\n";
+
+    net::tcp_acceptor<net::ip_version::v4> acceptor {net::endpoint_v4 {"0.0.0.0", 4433}};
+
+    // Set and get socket option example socket option for receive buffer size
+    acceptor.set_option(net::option<net::option_level::socket, SO_RCVBUF, int> {10000});
+    auto recv_buff_size = acceptor.get_option_value<net::option<net::option_level::socket, SO_RCVBUF, int>>();
+    std::cout << "Recvbuff size for accepting socket: " << recv_buff_size << '\n';
+
+    acceptor.async_accept(
+        [](auto sock)
+        {
+            std::array<char, 1024> buffer {};
+            auto len = sock.read(net::span {buffer});
+            std::cout << "Message read: " << std::string_view {buffer.data(), len} << '\n';
+        });
+
+    net::tcp_connection_v4 test_con {net::endpoint_v4 {"127.0.0.1", 4433, net::socket_type::stream}};
+    test_con.send(net::span {std::string_view {"Hello world"}});
+
+    // Get the peer security ctx
+    auto peer_ctx_opt = test_con.get_option<net::option<net::option_level::socket, SO_PEERSEC, char>>();
+    std::cout << peer_ctx_opt.value() << '\n';
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+}

--- a/example/tcp_example.cpp
+++ b/example/tcp_example.cpp
@@ -16,12 +16,6 @@ int main(int argc, char** argv)
         std::array<char, 10000> buffer;
         net::tcp_acceptor<net::ip_version::v4> acceptor {net::endpoint_v4 {"0.0.0.0", 4433}};
 
-        // Set and get socket option example socket option
-        acceptor.set_option(net::option<int> {net::socket_option::recv_buff_size, 50000});
-        auto recv_buff_size = acceptor.get_option_value<net::socket_option, int>(net::socket_option::recv_buff_size);
-
-        std::cout << "Recvbuff size for accepting socket: " << recv_buff_size << '\n';
-
         std::cout << "Waiting for accept\n";
         auto opt = acceptor.accept(std::chrono::milliseconds(5000));
         if(!opt)

--- a/example/tcp_example.cpp
+++ b/example/tcp_example.cpp
@@ -15,6 +15,12 @@ int main(int argc, char** argv)
 
         std::array<char, 10000> buffer;
         net::tcp_acceptor<net::ip_version::v4> acceptor {"0.0.0.0", 4433};
+
+        acceptor.set_option(net::socket_option::recv_buff_size, 10000);
+
+        int recv_buff_size = acceptor.get_option<net::socket_option, int>(net::socket_option::recv_buff_size);
+        std::cout << "Recvbuff size for accepting socket: " << recv_buff_size << '\n';
+
         std::cout << "Waiting for accept\n";
         // auto sock = acceptor.accept();
         auto opt = acceptor.accept(std::chrono::milliseconds(5000));

--- a/example/tcp_example.cpp
+++ b/example/tcp_example.cpp
@@ -14,15 +14,14 @@ int main(int argc, char** argv)
         std::cout << "--- Receiver ---\n";
 
         std::array<char, 10000> buffer;
-        net::tcp_acceptor<net::ip_version::v4> acceptor {"0.0.0.0", 4433};
+        net::tcp_acceptor<net::ip_version::v4> acceptor {net::endpoint_v4 {"0.0.0.0", 4433}};
 
+        // Set and get socket option
         acceptor.set_option(net::socket_option::recv_buff_size, 10000);
-
         int recv_buff_size = acceptor.get_option<net::socket_option, int>(net::socket_option::recv_buff_size);
         std::cout << "Recvbuff size for accepting socket: " << recv_buff_size << '\n';
 
         std::cout << "Waiting for accept\n";
-        // auto sock = acceptor.accept();
         auto opt = acceptor.accept(std::chrono::milliseconds(5000));
         if(!opt)
         {

--- a/example/tcp_example.cpp
+++ b/example/tcp_example.cpp
@@ -17,8 +17,9 @@ int main(int argc, char** argv)
         net::tcp_acceptor<net::ip_version::v4> acceptor {net::endpoint_v4 {"0.0.0.0", 4433}};
 
         // Set and get socket option example socket option
-        acceptor.set_option(net::option<net::option_level::socket, int> {SO_RCVBUF, 5000});
-        int recv_buff_size = acceptor.get_option_value<net::option<net::option_level::socket, int>>(SO_RCVBUF);
+        acceptor.set_option(net::option<int> {net::socket_option::recv_buff_size, 50000});
+        auto recv_buff_size = acceptor.get_option_value<net::socket_option, int>(net::socket_option::recv_buff_size);
+
         std::cout << "Recvbuff size for accepting socket: " << recv_buff_size << '\n';
 
         std::cout << "Waiting for accept\n";

--- a/example/tcp_example.cpp
+++ b/example/tcp_example.cpp
@@ -16,9 +16,9 @@ int main(int argc, char** argv)
         std::array<char, 10000> buffer;
         net::tcp_acceptor<net::ip_version::v4> acceptor {net::endpoint_v4 {"0.0.0.0", 4433}};
 
-        // Set and get socket option
-        acceptor.set_option(net::socket_option::recv_buff_size, 10000);
-        int recv_buff_size = acceptor.get_option<net::socket_option, int>(net::socket_option::recv_buff_size);
+        // Set and get socket option example socket option
+        acceptor.set_option(net::option<net::option_level::socket, int> {SO_RCVBUF, 5000});
+        int recv_buff_size = acceptor.get_option_value<net::option<net::option_level::socket, int>>(SO_RCVBUF);
         std::cout << "Recvbuff size for accepting socket: " << recv_buff_size << '\n';
 
         std::cout << "Waiting for accept\n";

--- a/include/socketwrapper/detail/base_socket.hpp
+++ b/include/socketwrapper/detail/base_socket.hpp
@@ -1,8 +1,8 @@
 #ifndef SOCKETWRAPPER_NET_INTERNAL_BASE_SOCKET_HPP
 #define SOCKETWRAPPER_NET_INTERNAL_BASE_SOCKET_HPP
 
-#include "../socket_option.hpp"
 #include "async.hpp"
+#include "socket_option.hpp"
 #include "utility.hpp"
 
 #include <type_traits>
@@ -73,7 +73,7 @@ public:
     template <typename OPTION_ENUM,
         typename OPTION_TYPE,
         typename = std::enable_if_t<std::is_same_v<OPTION_TYPE, int> || std::is_same_v<OPTION_TYPE, timeval> ||
-                std::is_same_v<OPTION_TYPE, linger>,
+                std::is_same_v<OPTION_TYPE, linger> || std::is_same_v<OPTION_TYPE, sockaddr>,
             bool>>
     void set_option(OPTION_ENUM opt_name, OPTION_TYPE&& opt_val)
     {
@@ -87,7 +87,7 @@ public:
     template <typename OPTION_ENUM,
         typename OPTION_TYPE,
         typename = std::enable_if_t<std::is_same_v<OPTION_TYPE, int> || std::is_same_v<OPTION_TYPE, timeval> ||
-                std::is_same_v<OPTION_TYPE, linger>,
+                std::is_same_v<OPTION_TYPE, linger> || std::is_same_v<OPTION_TYPE, sockaddr>,
             bool>>
     OPTION_TYPE get_option(socket_option opt_name) const
     {

--- a/include/socketwrapper/detail/base_socket.hpp
+++ b/include/socketwrapper/detail/base_socket.hpp
@@ -8,6 +8,26 @@
 
 namespace net {
 
+enum class socket_option : int
+{
+    debug = SO_DEBUG,
+    accept_conn = SO_ACCEPTCONN,
+    broadcast = SO_BROADCAST,
+    reuse_addr = SO_REUSEADDR,
+    keep_alive = SO_KEEPALIVE,
+    linger = SO_LINGER, // struct linger
+    oob_inline = SO_OOBINLINE,
+    send_buff = SO_SNDBUF,
+    recv_buff = SO_RCVBUF,
+    error = SO_ERROR,
+    type = SO_TYPE,
+    dont_route = SO_DONTROUTE,
+    recv_lowat = SO_RCVLOWAT,
+    recv_timeout = SO_RCVTIMEO, // struct timeval
+    send_lowat = SO_SNDLOWAT,
+    send_timeout = SO_SNDTIMEO // struct timeval
+};
+
 namespace detail {
 
 /// Very simple socket base class
@@ -65,6 +85,45 @@ public:
             detail::async_context::instance().deregister(m_sockfd);
             ::close(m_sockfd);
         }
+    }
+
+    template <typename OPTION_TYPE>
+    void set_option(socket_option opt_name, OPTION_TYPE&& opt_val)
+    {
+        // if(::setsockopt(m_sockfd, SOL_SOCKET, static_cast<int>(opt_name), &opt_val, sizeof(OPTION_TYPE)) != 0)
+        if(::setsockopt(m_sockfd, SOL_SOCKET, static_cast<int>(opt_name), &opt_val, sizeof(OPTION_TYPE)) != 0)
+            throw std::runtime_error {"Failed to set socket option."};
+    }
+
+    template <socket_option OPT_NAME>
+    void set_option(const std::variant<int, timeval, linger>& opt_val)
+    {
+        if constexpr(OPT_NAME == socket_option::linger)
+        {
+            const linger& casted_val = std::get<linger>(opt_val);
+            ::setsockopt(m_sockfd, SOL_SOCKET, static_cast<int>(OPT_NAME), &casted_val, sizeof(linger));
+        }
+        else if constexpr(OPT_NAME == socket_option::recv_timeout || OPT_NAME == socket_option::send_timeout)
+        {
+            const timeval& casted_val = std::get<timeval>(opt_val);
+            ::setsockopt(m_sockfd, SOL_SOCKET, static_cast<int>(OPT_NAME), &casted_val, sizeof(timeval));
+        }
+        else
+        {
+            const int& casted_val = std::get<int>(opt_val);
+            ::setsockopt(m_sockfd, SOL_SOCKET, static_cast<int>(OPT_NAME), &casted_val, sizeof(int));
+        }
+    }
+
+    template <typename OPTION_TYPE>
+    OPTION_TYPE get_option(socket_option opt_name) const
+    {
+        OPTION_TYPE opt_val {};
+        size_t opt_len {};
+        if(::getsockopt(m_sockfd, SOL_SOCKET, static_cast<int>(opt_name), &opt_val, &opt_len) != 0 ||
+            opt_len != sizeof(OPTION_TYPE))
+            throw std::runtime_error {"Failed to receive socket option."};
+        return opt_val;
     }
 
     int get() const

--- a/include/socketwrapper/detail/base_socket.hpp
+++ b/include/socketwrapper/detail/base_socket.hpp
@@ -53,13 +53,9 @@ public:
         if(m_sockfd == -1)
             throw std::runtime_error {"Failed to create socket."};
 
-        const int reuse = 1;
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
-            throw std::runtime_error {"Failed to set address reusable."};
-
+        set_option(option<option_level::socket, SO_REUSEADDR, int> {1});
 #ifdef SO_REUSEPORT
-        if(::setsockopt(m_sockfd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
-            throw std::runtime_error {"Failed to set port reusable."};
+        set_option(option<option_level::socket, SO_REUSEPORT, int> {1});
 #endif
     }
 
@@ -80,7 +76,7 @@ public:
         if(::setsockopt(m_sockfd,
                opt_val.level_native(),
                opt_val.name(),
-               reinterpret_cast<const char*>(&opt_val.value()),
+               reinterpret_cast<const char*>(opt_val.value()),
                opt_len) != 0)
         {
             throw std::runtime_error {"Failed to set socket option."};
@@ -94,7 +90,7 @@ public:
         OPTION_TYPE opt_val {};
         unsigned int opt_len = opt_val.size();
         if(::getsockopt(
-               m_sockfd, opt_val.level_native(), opt_val.name(), reinterpret_cast<char*>(&opt_val.value()), &opt_len) !=
+               m_sockfd, opt_val.level_native(), opt_val.name(), reinterpret_cast<char*>(opt_val.value()), &opt_len) !=
             0)
         {
             throw std::runtime_error {"Failed to get socket option."};
@@ -106,7 +102,7 @@ public:
         typename = std::enable_if_t<detail::is_template_of<OPTION_TYPE, option>::value, bool>>
     typename OPTION_TYPE::value_type get_option_value() const
     {
-        return get_option<OPTION_TYPE>().value();
+        return *get_option<OPTION_TYPE>().value();
     }
 
     int get() const

--- a/include/socketwrapper/detail/socket_option.hpp
+++ b/include/socketwrapper/detail/socket_option.hpp
@@ -13,149 +13,59 @@
 
 namespace net {
 
-enum class socket_option : int
-{
-    debug = SO_DEBUG,
-    accept_conn = SO_ACCEPTCONN,
-    broadcast = SO_BROADCAST,
-    reuse_addr = SO_REUSEADDR,
-    reuse_port = SO_REUSEPORT,
-    keep_alive = SO_KEEPALIVE,
-    linger = SO_LINGER, // struct linger
-    oob_inline = SO_OOBINLINE,
-    send_buff_size = SO_SNDBUF,
-    recv_buff_size = SO_RCVBUF,
-    recv_buff_size_force = SO_RCVBUFFORCE,
-    error = SO_ERROR,
-    type = SO_TYPE,
-    dont_route = SO_DONTROUTE,
-    recv_lowat = SO_RCVLOWAT,
-    recv_timeout = SO_RCVTIMEO, // struct timeval
-    send_lowat = SO_SNDLOWAT,
-    send_timeout = SO_SNDTIMEO, // struct timeval
-    busy_poll = SO_BUSY_POLL,
-    priority = SO_PRIORITY,
-    peek_offset = SO_PEEK_OFF,
-    peer_security_ctx = SO_PEERSEC,
-    peer_credentials = SO_PEERCRED,
-    pass_sec_msg = SO_PASSSEC,
-    pass_credentials = SO_PASSCRED,
-    select_cpu = SO_INCOMING_CPU
-};
-
-enum class ipv4_option : int
-{
-    user_supplied_header = IP_HDRINCL,
-    options = IP_OPTIONS,
-    type_of_service = IP_TOS,
-    time_to_live = IP_TTL,
-    multicast_interface = IP_MULTICAST_IF,
-    multicast_time_to_live = IP_MULTICAST_TTL,
-    multicast_loop = IP_MULTICAST_LOOP,
-    multicast_add = IP_ADD_MEMBERSHIP,
-    multicast_drop = IP_DROP_MEMBERSHIP
-};
-
-enum class ipv6_option : int
-{
-    address_format = IPV6_ADDRFORM,
-    hop_limit = IPV6_HOPLIMIT,
-    hop_options = IPV6_HOPOPTS,
-    next_hop = IPV6_NEXTHOP,
-    packet_info = IPV6_PKTINFO,
-    multicast_interface = IPV6_MULTICAST_IF,
-    multicast_hops = IPV6_MULTICAST_HOPS,
-    multicast_loop = IPV6_MULTICAST_LOOP,
-    multicast_add = IPV6_ADD_MEMBERSHIP,
-    multicast_drop = IPV6_DROP_MEMBERSHIP
-};
-
-enum class tcp_option : int
-{
-    max_seg_size = TCP_MAXSEG,
-    no_delay = TCP_NODELAY
-};
-
 namespace detail {
 
-template <typename OPTION_TYPE>
-struct option_level;
-
-template <>
-struct option_level<socket_option>
-{
-    static constexpr const int value = SOL_SOCKET;
-};
-
-template <>
-struct option_level<ipv4_option>
-{
-    static constexpr const int value = IPPROTO_IP;
-};
-
-template <>
-struct option_level<ipv6_option>
-{
-    static constexpr const int value = IPPROTO_IPV6;
-};
-
-template <>
-struct option_level<tcp_option>
-{
-    static constexpr const int value = IPPROTO_TCP;
-};
-
-template <typename TEST_TYPE, template <typename> class REF_TYPE>
+template <typename TEST_TYPE, template <auto, auto, typename> class REF_TYPE>
 struct is_template_of : std::false_type
 {};
 
-template <template <typename> typename REF_TYPE, typename T>
-struct is_template_of<REF_TYPE<T>, REF_TYPE> : std::true_type
+template <template <auto, auto, typename> typename REF_TYPE, auto LEVEL, auto NAME, typename T>
+struct is_template_of<REF_TYPE<LEVEL, NAME, T>, REF_TYPE> : std::true_type
 {};
 
 } // namespace detail
 
-template <typename T>
+enum class option_level : int
+{
+    socket = SOL_SOCKET,
+    ipv4 = IPPROTO_IP,
+    ipv6 = IPPROTO_IPV6,
+    tcp = IPPROTO_TCP
+};
+
+template <option_level, int, typename>
 class option;
 
-template <>
-class option<int>
+template <option_level LEVEL, int NAME>
+class option<LEVEL, NAME, int>
 {
 public:
     using value_type = int;
 
-    option(int name, int level)
-        : m_name {name}
-        , m_level {level}
+    option() = default;
+
+    option(int value)
+        : m_value {value}
     {}
 
-    option(int name, int level, bool value)
-        : m_name {name}
-        , m_level {level}
-        , m_value {value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name, int val)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-        , m_value {val}
-    {}
-
-    const int& name() const
+    size_t size() const
     {
-        return m_name;
+        return sizeof(int);
     }
 
-    const int& level() const
+    int name() const
     {
-        return m_level;
+        return NAME;
+    }
+
+    option_level level() const
+    {
+        return LEVEL;
+    }
+
+    int level_native() const
+    {
+        return static_cast<int>(LEVEL);
     }
 
     const int& value() const
@@ -169,57 +79,41 @@ public:
     }
 
 private:
-    int m_name;
-    int m_level;
     int m_value;
 };
 
-template <>
-class option<char>
+template <option_level LEVEL, int NAME>
+class option<LEVEL, NAME, char>
 {
 public:
     using value_type = char;
 
-    option(int name, int level)
-        : m_name {name}
-        , m_level {level}
-    {}
+    option() = default;
 
-    option(int name, int level, std::string_view value)
-        : m_name {name}
-        , m_level {level}
+    option(std::string_view value)
     {
         if(value.size() <= NAME_MAX)
             std::copy_n(value.begin(), value.size(), m_value.begin());
-        else
-            throw std::runtime_error {"Failed to create option from string_view."};
     }
 
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name, std::string_view value)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
+    size_t size() const
     {
-        if(value.size() <= NAME_MAX)
-            std::copy_n(value.begin(), value.size(), m_value.begin());
-        else
-            throw std::runtime_error {"Failed to create option from string_view."};
+        return NAME_MAX;
     }
 
-    const int& name() const
+    int name() const
     {
-        return m_name;
+        return NAME;
     }
 
-    const int& level() const
+    option_level level() const
     {
-        return m_level;
+        return LEVEL;
+    }
+
+    int level_native() const
+    {
+        return static_cast<int>(LEVEL);
     }
 
     const char& value() const
@@ -233,47 +127,38 @@ public:
     }
 
 private:
-    int m_name;
-    int m_level;
     std::array<char, NAME_MAX> m_value;
 };
 
-template <>
-class option<bool>
+template <option_level LEVEL, int NAME>
+class option<LEVEL, NAME, bool>
 {
     using value_type = bool;
 
-    option(int name, int level)
-        : m_name {name}
-        , m_level {level}
+    option() = default;
+
+    option(bool value)
+        : m_value {value}
     {}
 
-    option(int name, int level, bool value)
-        : m_name {name}
-        , m_level {level}
-        , m_value {value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name, bool val)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-        , m_value {val}
-    {}
-    const int& name() const
+    size_t size() const
     {
-        return m_name;
+        return sizeof(bool);
     }
 
-    const int& level() const
+    int name() const
     {
-        return m_level;
+        return NAME;
+    }
+
+    option_level level() const
+    {
+        return LEVEL;
+    }
+
+    int level_native() const
+    {
+        return static_cast<int>(LEVEL);
     }
 
     const bool& value() const
@@ -287,49 +172,39 @@ class option<bool>
     }
 
 private:
-    int m_name;
-    int m_level;
     bool m_value;
 };
 
-template <>
-class option<linger>
+template <option_level LEVEL, int NAME>
+class option<LEVEL, NAME, linger>
 {
 public:
     using value_type = linger;
 
-    option(int name, int level)
-        : m_name {name}
-        , m_level {level}
+    option() = default;
+
+    option(const linger& value)
+        : m_value {value}
     {}
 
-    option(int name, int level, const linger& value)
-        : m_name {name}
-        , m_level {level}
-        , m_value {value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name, const linger& val)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-        , m_value {val}
-    {}
-
-    const int& name() const
+    size_t size() const
     {
-        return m_name;
+        return sizeof(linger);
     }
 
-    const int& level() const
+    int name() const
     {
-        return m_level;
+        return NAME;
+    }
+
+    option_level level() const
+    {
+        return LEVEL;
+    }
+
+    int level_native() const
+    {
+        return static_cast<int>(LEVEL);
     }
 
     const linger& value() const
@@ -343,49 +218,39 @@ public:
     }
 
 private:
-    int m_name;
-    int m_level;
     linger m_value;
 };
 
-template <>
-class option<sockaddr>
+template <option_level LEVEL, int NAME>
+class option<LEVEL, NAME, sockaddr>
 {
 public:
     using value_type = sockaddr;
 
-    option(int name, int level)
-        : m_name {name}
-        , m_level {level}
+    option() = default;
+
+    option(const sockaddr& value)
+        : m_value {value}
     {}
 
-    option(int name, int level, const sockaddr& value)
-        : m_name {name}
-        , m_level {level}
-        , m_value {value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-    {}
-
-    template <typename OPTION_ENUM>
-    option(OPTION_ENUM name, const sockaddr& value)
-        : m_name {static_cast<int>(name)}
-        , m_level {detail::option_level<OPTION_ENUM>::value}
-        , m_value {value}
-    {}
-
-    const int& name() const
+    size_t size() const
     {
-        return m_name;
+        return sizeof(sockaddr);
     }
 
-    const int& level() const
+    int name() const
     {
-        return m_level;
+        return NAME;
+    }
+
+    option_level level() const
+    {
+        return LEVEL;
+    }
+
+    int level_native() const
+    {
+        return static_cast<int>(LEVEL);
     }
 
     const sockaddr& value() const
@@ -399,8 +264,6 @@ public:
     }
 
 private:
-    int m_name;
-    int m_level;
     sockaddr m_value;
 };
 

--- a/include/socketwrapper/detail/socket_option.hpp
+++ b/include/socketwrapper/detail/socket_option.hpp
@@ -68,14 +68,14 @@ public:
         return static_cast<int>(LEVEL);
     }
 
-    const int& value() const
+    const int* value() const
     {
-        return m_value;
+        return &m_value;
     }
 
-    int& value()
+    int* value()
     {
-        return m_value;
+        return &m_value;
     }
 
 private:
@@ -116,14 +116,14 @@ public:
         return static_cast<int>(LEVEL);
     }
 
-    const char& value() const
+    const char* value() const
     {
-        return m_value.front();
+        return m_value.data();
     }
 
-    char& value()
+    char* value()
     {
-        return m_value.front();
+        return m_value.data();
     }
 
 private:
@@ -161,14 +161,14 @@ class option<LEVEL, NAME, bool>
         return static_cast<int>(LEVEL);
     }
 
-    const bool& value() const
+    const bool* value() const
     {
-        return m_value;
+        return &m_value;
     }
 
-    bool& value()
+    bool* value()
     {
-        return m_value;
+        return &m_value;
     }
 
 private:
@@ -207,14 +207,14 @@ public:
         return static_cast<int>(LEVEL);
     }
 
-    const linger& value() const
+    const linger* value() const
     {
-        return m_value;
+        return &m_value;
     }
 
-    linger& value()
+    linger* value()
     {
-        return m_value;
+        return &m_value;
     }
 
 private:
@@ -253,14 +253,14 @@ public:
         return static_cast<int>(LEVEL);
     }
 
-    const sockaddr& value() const
+    const sockaddr* value() const
     {
-        return m_value;
+        return &m_value;
     }
 
-    sockaddr& value()
+    sockaddr* value()
     {
-        return m_value;
+        return &m_value;
     }
 
 private:

--- a/include/socketwrapper/detail/socket_option.hpp
+++ b/include/socketwrapper/detail/socket_option.hpp
@@ -27,10 +27,31 @@ enum class socket_option : int
 };
 
 enum class ipv4_option : int
-{};
+{
+    user_supplied_header = IP_HDRINCL,
+    options = IP_OPTIONS,
+    type_of_service = IP_TOS,
+    time_to_live = IP_TTL,
+    multicast_interface = IP_MULTICAST_IF,
+    multicast_time_to_live = IP_MULTICAST_TTL,
+    multicast_loop = IP_MULTICAST_LOOP,
+    multicast_add = IP_ADD_MEMBERSHIP,
+    multicast_drop = IP_DROP_MEMBERSHIP
+};
 
 enum class ipv6_option : int
-{};
+{
+    address_format = IPV6_ADDRFORM,
+    hop_limit = IPV6_HOPLIMIT,
+    hop_options = IPV6_HOPOPTS,
+    next_hop = IPV6_NEXTHOP,
+    packet_info = IPV6_PKTINFO,
+    multicast_interface = IPV6_MULTICAST_IF,
+    multicast_hops = IPV6_MULTICAST_HOPS,
+    multicast_loop = IPV6_MULTICAST_LOOP,
+    multicast_add = IPV6_ADD_MEMBERSHIP,
+    multicast_drop = IPV6_DROP_MEMBERSHIP
+};
 
 enum class tcp_option : int
 {

--- a/include/socketwrapper/detail/utility.hpp
+++ b/include/socketwrapper/detail/utility.hpp
@@ -25,7 +25,7 @@ enum class ip_version : uint8_t
 
 enum class socket_type : uint8_t
 {
-    unspecified = PF_UNSPEC,
+    unspecified = AF_UNSPEC,
     stream = SOCK_STREAM,
     datagram = SOCK_DGRAM
 };

--- a/include/socketwrapper/socket_option.hpp
+++ b/include/socketwrapper/socket_option.hpp
@@ -1,0 +1,75 @@
+#ifndef SOCKETWRAPPER_NET_SOCKET_OPTION_HPP
+#define SOCKETWRAPPER_NET_SOCKET_OPTION_HPP
+
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+namespace net {
+
+enum class socket_option : int
+{
+    debug = SO_DEBUG,
+    accept_conn = SO_ACCEPTCONN,
+    broadcast = SO_BROADCAST,
+    reuse_addr = SO_REUSEADDR,
+    keep_alive = SO_KEEPALIVE,
+    linger = SO_LINGER, // struct linger
+    oob_inline = SO_OOBINLINE,
+    send_buff_size = SO_SNDBUF,
+    recv_buff_size = SO_RCVBUF,
+    error = SO_ERROR,
+    type = SO_TYPE,
+    dont_route = SO_DONTROUTE,
+    recv_lowat = SO_RCVLOWAT,
+    recv_timeout = SO_RCVTIMEO, // struct timeval
+    send_lowat = SO_SNDLOWAT,
+    send_timeout = SO_SNDTIMEO // struct timeval
+};
+
+enum class ipv4_option : int
+{};
+
+enum class ipv6_option : int
+{};
+
+enum class tcp_option : int
+{
+    // max_retransmission = TCP_MAXRT,
+    max_seg_size = TCP_MAXSEG,
+    // keep_alive = TCP_KEEPALIVE
+};
+
+namespace detail {
+
+template <typename OPTION_TYPE>
+struct option;
+
+template <>
+struct option<socket_option>
+{
+    static constexpr const int level = SOL_SOCKET;
+};
+
+template <>
+struct option<ipv4_option>
+{
+    static constexpr const int level = IPPROTO_IP;
+};
+
+template <>
+struct option<ipv6_option>
+{
+    static constexpr const int level = IPPROTO_IPV6;
+};
+
+template <>
+struct option<tcp_option>
+{
+    static constexpr const int level = IPPROTO_TCP;
+};
+
+} // namespace detail
+
+} // namespace net
+
+#endif


### PR DESCRIPTION
This MR adds a new class ```net::option<net::option_level LEVEL, int NAME, typename T>``` to represent socket options with multiple internal value types. Also a function to get and set those options was implemented on the ```net::base_socket``` class.

Closes #19 