### PR TITLE
Fixed compile error

### DIFF
--- a/include/socketwrapper/detail/event_notifier_epoll.hpp
+++ b/include/socketwrapper/detail/event_notifier_epoll.hpp
@@ -183,13 +183,15 @@ public:
                 }
                 else if (ready_set[i].events & static_cast<uint32_t>(event_type::READ))
                 {
-                    unwatch(ready_set[i].data.fd, event_type::READ);
-                    return std::make_pair(ready_set[i].data.fd, event_type::READ);
+                    int fd = ready_set[i].data.fd;
+                    unwatch(fd, event_type::READ);
+                    return std::make_pair(fd, event_type::READ);
                 }
                 else if (ready_set[i].events & static_cast<uint32_t>(event_type::WRITE))
                 {
-                    unwatch(ready_set[i].data.fd, event_type::WRITE);
-                    return std::make_pair(ready_set[i].data.fd, event_type::WRITE);
+                    int fd = ready_set[i].data.fd;
+                    unwatch(fd, event_type::WRITE);
+                    return std::make_pair(fd, event_type::WRITE);
                 }
             }
         }

--- a/include/socketwrapper/detail/event_notifier_kqueue.hpp
+++ b/include/socketwrapper/detail/event_notifier_kqueue.hpp
@@ -153,8 +153,9 @@ public:
                 else if (ready_set[i].filter == static_cast<int16_t>(event_type::READ) ||
                     ready_set[i].filter == static_cast<int16_t>(event_type::WRITE))
                 {
-                    unwatch(ready_set[i].ident, static_cast<event_type>(ready_set[i].filter));
-                    return std::make_pair(ready_set[i].ident, static_cast<event_type>(ready_set[i].filter));
+                    int fd = ready_set[i].ident;
+                    unwatch(fd, static_cast<event_type>(ready_set[i].filter));
+                    return std::make_pair(fd, static_cast<event_type>(ready_set[i].filter));
                 }
             }
         }


### PR DESCRIPTION
This commit fixes a compile error with GCC 12.2.0 on Debian 12.4
The error was the following:
`g++ -o udp_example udp_example.cpp -std=c++17 -fpic -Wall -Werror -Wextra -pedantic -lpthread
In file included from ../include/socketwrapper/detail/event_notifier.hpp:7,
                 from ../include/socketwrapper/detail/executor.hpp:5,
                 from ../include/socketwrapper/detail/base_socket.hpp:4,
                 from ../include/socketwrapper/udp.hpp:4,
                 from udp_example.cpp:1:
../include/socketwrapper/detail/event_notifier_epoll.hpp: In member function ‘std::optional<std::pair<int, net::detail::event_type> > net::detail::event_notifier_epoll::next_event()’:
../include/socketwrapper/detail/event_notifier_epoll.hpp:187:61: error: cannot bind packed field ‘ready_set.std::array<epoll_event, 64>::operator[](((std::array<epoll_event, 64>::size_type)i)).epoll_event::data.epoll_data::fd’ to ‘int&’
  187 |                     return std::make_pair(ready_set[i].data.fd, event_type::READ);
../include/socketwrapper/detail/event_notifier_epoll.hpp:192:61: error: cannot bind packed field ‘ready_set.std::array<epoll_event, 64>::operator[](((std::array<epoll_event, 64>::size_type)i)).epoll_event::data.epoll_data::fd’ to ‘int&’
  192 |                     return std::make_pair(ready_set[i].data.fd, event_type::WRITE);
make: *** [Makefile:31 : udp] Erreur 1
`