### PR TITLE
Added Unix domain socket support

### DIFF
--- a/example/unix_dgram_example.cpp
+++ b/example/unix_dgram_example.cpp
@@ -1,0 +1,54 @@
+#include "../include/socketwrapper/unixdgram.hpp"
+#include <cstring>
+#include <iostream>
+#include <thread>
+
+int main(int argc, char** argv)
+{
+    if (argc <= 1)
+        return 0;
+
+    if (strcmp(argv[1], "r") == 0)
+    {
+        std::cout << "--- Receiver ---\n";
+
+        auto sock = net::unix_dgram_socket(net::endpoint_unix("/tmp/sock2"));
+
+        auto buffer = std::array<char, 1024>{};
+        const auto [bytes_read, peer] = sock.read(net::span(buffer));
+        std::cout << "Peer addr: " << peer.get_addr_string()
+                  << "; Bytes read: " << bytes_read << '\n';
+        std::cout << std::string_view(buffer.data(), bytes_read) << '\n';
+
+        const auto read_result = sock.read(net::span{buffer}, std::chrono::milliseconds(4000));
+        if (read_result.has_value())
+        {
+            const auto& [bytes_read, peer_opt] = read_result.value();
+            std::cout << "Peer addr: " << peer_opt.get_addr_string()
+                      << "; Bytes read: " << bytes_read << '\n';
+            std::cout << std::string_view{buffer.data(), bytes_read} << '\n';
+        }
+        else
+        {
+            std::cout << "No message received :(\n";
+        }
+    }
+    else if (strcmp(argv[1], "s") == 0)
+    {
+        std::cout << "--- Sender ---\n";
+
+        auto sock = net::unix_dgram_socket();
+
+        auto buffer = std::string{"Hello world"};
+        const auto endpoint = net::endpoint_unix("/tmp/sock2");
+        sock.send(endpoint, net::span(buffer));
+        std::cout << "All messages sent." << std::endl;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+        auto vec = std::vector<char>{'A', 'B', 'C'};
+        sock.send(endpoint, net::span(vec));
+        sock.send(endpoint, net::span("KekWWW"));
+        std::cout << "All messages sent. Again." << std::endl;
+    }
+}

--- a/example/unix_stream_example.cpp
+++ b/example/unix_stream_example.cpp
@@ -1,0 +1,63 @@
+#include "../include/socketwrapper/unixstream.hpp"
+
+#include <cstring>
+#include <iostream>
+#include <thread>
+
+int main(int argc, char** argv)
+{
+    if (argc <= 1)
+        return 0;
+
+    if (strcmp(argv[1], "r") == 0)
+    {
+        std::cout << "--- Receiver ---\n";
+
+        auto buffer = std::array<char, 10000>{};
+        auto acceptor = net::unix_stream_acceptor(net::endpoint_unix("/tmp/sock1"));
+
+        std::cout << "Waiting for accept\n";
+        auto opt = acceptor.accept(std::chrono::milliseconds(5000));
+        if (!opt)
+        {
+            std::cout << "No acception\n";
+            return 0;
+        }
+        const auto& sock = opt.value();
+        std::cout << "Accepted\n";
+
+        std::cout << "Wait for data ...\n";
+        size_t bytes_read = sock.read(net::span{buffer});
+        std::cout << "Received: " << bytes_read << " - " << std::string_view{buffer.data(), bytes_read} << '\n';
+
+        const auto read_result = sock.read(net::span{buffer}, std::chrono::milliseconds(4000));
+        if (read_result.has_value())
+        {
+            std::cout << "Received: " << *read_result << " - " << std::string_view{buffer.data(), *read_result} << '\n';
+        }
+    }
+    else if (strcmp(argv[1], "s") == 0)
+    {
+        std::cout << "--- Sender ---\n";
+
+        auto sock = net::unix_stream_connection();
+        std::cout << "Socket created\n";
+
+        sock.connect(net::endpoint_unix("/tmp/sock1"));
+        std::cout << "Connected\n";
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+
+        auto vec = std::vector<char>{'H', 'e', 'l', 'l', 'o'};
+        // sock.send(net::span{vec});
+        // sock.send(net::span{std::string {"Hello World"}});
+        sock.send(net::span{vec.begin(), vec.end()});
+        std::cout << "Sent\n";
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+        auto buffer_view = std::string_view{"Hello String_view-World"};
+        sock.send(net::span{buffer_view.begin(), buffer_view.end()});
+        std::cout << "Sent again\n";
+    }
+}

--- a/include/socketwrapper/detail/utility.hpp
+++ b/include/socketwrapper/detail/utility.hpp
@@ -20,7 +20,8 @@ namespace net {
 enum class ip_version : uint8_t
 {
     v4 = AF_INET,
-    v6 = AF_INET6
+    v6 = AF_INET6,
+    unixsock = AF_UNIX
 };
 
 enum class socket_type : uint8_t

--- a/include/socketwrapper/tcp.hpp
+++ b/include/socketwrapper/tcp.hpp
@@ -333,8 +333,8 @@ protected:
         {
             auto client_addr = endpoint<ip_ver_v>();
             socklen_t addr_len = client_addr.addr_size;
-            if (const int sock = ::accept(fd, &(client_addr.get_addr()), &addr_len);
-                sock > 0 && addr_len == client_addr.addr_size)
+            const int sock = ::accept(fd, &(client_addr.get_addr()), &addr_len);
+            if (sock > 0 && client_addr.is_valid_addr_size(addr_len))
             {
                 return std::move(tcp_connection<ip_ver_v>{sock, client_addr});
             }

--- a/include/socketwrapper/unixdgram.hpp
+++ b/include/socketwrapper/unixdgram.hpp
@@ -1,0 +1,12 @@
+#ifndef SOCKETWRAPPER_NET_UNIXDGRAM_HPP
+#define SOCKETWRAPPER_NET_UNIXDGRAM_HPP
+
+#include "udp.hpp"
+
+namespace net {
+
+using unix_dgram_socket = udp_socket<ip_version::unixsock>;
+
+} // namespace net
+
+#endif

--- a/include/socketwrapper/unixstream.hpp
+++ b/include/socketwrapper/unixstream.hpp
@@ -1,0 +1,13 @@
+#ifndef SOCKETWRAPPER_NET_UNIXSTREAM_HPP
+#define SOCKETWRAPPER_NET_UNIXSTREAM_HPP
+
+#include "tcp.hpp"
+
+namespace net {
+
+using unix_stream_connection = tcp_connection<ip_version::unixsock>;
+using unix_stream_acceptor = tcp_acceptor<ip_version::unixsock>;
+
+} // namespace net
+
+#endif


### PR DESCRIPTION
This adds support for Unix domain sockets (both datagrams and streams). It is mostly a hack, and if there is interest in this feature, it might be worthwhile to refactor the main code a bit. For instance, by introducing base classes for datagrams (to be derived for UDP and Unix datagrams) and streams (to be derived for TCP and Unix streams). Ideally, the ip_version parameter should also be renamed to something more generic, like family.

That said, this branch works as intended and remains fully backward compatible with previous versions.